### PR TITLE
Upgrade to Spring Boot 2.0.0.M7

### DIFF
--- a/stock-quotes-mvc/pom.xml
+++ b/stock-quotes-mvc/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.0.M6</version>
+        <version>2.0.0.M7</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -22,8 +22,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <spring.version>5.0.2.RELEASE</spring.version>
-        <reactor-bom.version>Bismuth-SR4</reactor-bom.version>
     </properties>
 
     <dependencies>

--- a/stock-quotes-webflux/pom.xml
+++ b/stock-quotes-webflux/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.0.M6</version>
+        <version>2.0.0.M7</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -22,8 +22,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <spring.version>5.0.2.RELEASE</spring.version>
-        <reactor-bom.version>Bismuth-SR4</reactor-bom.version>
     </properties>
 
     <dependencies>

--- a/trading-service-webflux/pom.xml
+++ b/trading-service-webflux/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.0.M6</version>
+        <version>2.0.0.M7</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -22,8 +22,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <spring.version>5.0.2.RELEASE</spring.version>
-        <reactor-bom.version>Bismuth-SR4</reactor-bom.version>
     </properties>
 
     <dependencies>

--- a/trading-service-webflux/src/main/resources/templates/quotes.html
+++ b/trading-service-webflux/src/main/resources/templates/quotes.html
@@ -79,7 +79,7 @@
             })
             .forEach(function (serie) {
                 var shift = serie.data.length > 40;
-                serie.addPoint([quote.instant * 1000, quote.price], true, shift);
+                serie.addPoint([Date.parse(quote.instant), quote.price], true, shift);
             });
     };
 


### PR DESCRIPTION
This commit updates the applications to Spring Boot 2.0.0.M7.

One small change is required in the JS client. Since in
spring-projects/spring-boot#11079 the Jackson serialization format
for dates has been flipped, the client needs to parse the date instead
of just processing it as raw EPOCH time.